### PR TITLE
Fix stream.write() and server.emit() overrides to call the original methods with the correct this context

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -47,7 +47,7 @@ ReqCounter.prototype.registerEvents = function (server) {
     server.emit = function () {
         var args = arguments;
         if (args[0] !== 'connection' && args[0] !== 'request') {
-            origEmit.apply(server, arguments);
+            origEmit.apply(this, arguments);
             return;
         }
 
@@ -65,7 +65,7 @@ ReqCounter.prototype.registerEvents = function (server) {
                 if (data && data.length) {
                     that._transfered += data.length;
                 }
-                origWrite.apply(stream, arguments);
+                origWrite.apply(this, arguments);
             };
 
             stream.on('close', function () {
@@ -103,7 +103,7 @@ ReqCounter.prototype.registerEvents = function (server) {
             };
             /*jslint plusplus:true*/
         }
-        origEmit.apply(server, arguments);
+        origEmit.apply(this, arguments);
     };
 };
 


### PR DESCRIPTION
Contributed on behalf of Box Inc.
