### PR TITLE
src: fix compile errors with nan 1.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-    - "0.8"
     - "0.10"
+    - "0.11"

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -31,8 +31,11 @@
 #include <string>
 #include <vector>
 
+
+#include "nan.h"
+
 #define NODE_PROTECTED_PROPERTY(obj, name, getter, setter)                \
-  obj->SetAccessor(v8::String::NewSymbol(name), getter, setter,           \
+  obj->SetAccessor(NanNew(name), getter, setter,           \
                    v8::Handle<v8::Value>(), PROHIBITS_OVERWRITING,        \
                     DontDelete)
 


### PR DESCRIPTION
make: Entering directory `/home/rh/monitr/build'
  CXX(target) Release/obj.target/monitor/src/monitor.o
../src/monitor.cc:123:7: warning: extra tokens at end of #endif directive
../src/monitor.cc: In static member function ‘static void node::NodeMonitor::setStatistics()’:
../src/monitor.cc:158: error: ‘nan_isolate’ was not declared in this scope
../src/monitor.cc: In function ‘v8::Localv8::Value node::callFunction(const char_)’:
../src/monitor.cc:349: error: ‘GetCurrent’ is not a member of ‘v8::Context’
../src/monitor.cc:359: error: ‘GetCurrent’ is not a member of ‘v8::Context’
../src/monitor.cc: In function ‘void node::LogStackTrace(v8::Handlev8::Object)’:
../src/monitor.cc:606: error: no matching function for call to ‘v8::Number::New(int&)’
/home/rh/.node-gyp/0.11.13/deps/v8/include/v8.h:2061: note: candidates are: static v8::Localv8::Number v8::Number::New(v8::Isolate_, double)
../src/monitor.cc: In function ‘void node::init(v8::Handlev8::Object)’:
../src/monitor.cc:684: error: ‘NewSymbol’ is not a member of ‘v8::String’
../src/monitor.cc:685: warning: ‘v8::Localv8::String NanSymbol(const char_, int)’ is deprecated (declared at ../node_modules/nan/nan.h:727)
../src/monitor.cc:685: warning: ‘v8::Localv8::String NanSymbol(const char_, int)’ is deprecated (declared at ../node_modules/nan/nan.h:727)
../src/monitor.cc:686: error: no matching function for call to ‘v8::FunctionTemplate::New(void (&)(const v8::FunctionCallbackInfov8::Value&))’
/home/rh/.node-gyp/0.11.13/deps/v8/include/v8.h:3519: note: candidates are: static v8::Localv8::FunctionTemplate v8::FunctionTemplate::New(v8::Isolate_, void (_)(const v8::FunctionCallbackInfov8::Value&), v8::Handlev8::Value, v8::Handlev8::Signature, int)
../src/monitor.cc:687: warning: ‘v8::Localv8::String NanSymbol(const char_, int)’ is deprecated (declared at ../node_modules/nan/nan.h:727)
../src/monitor.cc:687: warning: ‘v8::Localv8::String NanSymbol(const char_, int)’ is deprecated (declared at ../node_modules/nan/nan.h:727)
../src/monitor.cc:688: error: no matching function for call to ‘v8::FunctionTemplate::New(void (&)(const v8::FunctionCallbackInfov8::Value&))’
/home/rh/.node-gyp/0.11.13/deps/v8/include/v8.h:3519: note: candidates are: static v8::Localv8::FunctionTemplate v8::FunctionTemplate::New(v8::Isolate_, void (_)(const v8::FunctionCallbackInfov8::Value&), v8::Handlev8::Value, v8::Handlev8::Signature, int)
../src/monitor.cc:689: warning: ‘v8::Localv8::String NanSymbol(const char_, int)’ is deprecated (declared at ../node_modules/nan/nan.h:727)
../src/monitor.cc:689: warning: ‘v8::Localv8::String NanSymbol(const char_, int)’ is deprecated (declared at ../node_modules/nan/nan.h:727)
../src/monitor.cc:690: error: no matching function for call to ‘v8::FunctionTemplate::New(void (&)(const v8::FunctionCallbackInfov8::Value&))’
/home/rh/.node-gyp/0.11.13/deps/v8/include/v8.h:3519: note: candidates are: static v8::Localv8::FunctionTemplate v8::FunctionTemplate::New(v8::Isolate_, void (_)(const v8::FunctionCallbackInfov8::Value&), v8::Handlev8::Value, v8::Handlev8::Signature, int)
../src/monitor.cc: At global scope:
../src/monitor.cc:663: warning: ‘void node::SignalHangupHandler(int)’ defined but not used
