### PR TITLE
Only log BREAK events generated by v8::Debug::DebugBreak()

### DIFF
--- a/examples/monitor_me.js
+++ b/examples/monitor_me.js
@@ -4,6 +4,7 @@
  * See the accompanying LICENSE file for terms.
  */
 var http = require('http'),
+    url = require('url'),
     monitor = require('..');
 
 /* 
@@ -16,12 +17,31 @@ var http = require('http'),
  */
 monitor.start();
 
+function fib(n) {
+  if (n<2)
+    return 1;
+  else
+    return fib(n-2) + fib(n-1);
+}
+
 /*
  * Start a simple http server
  */
 http.createServer(function (req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
-  res.end('I am being monitored\n');
+  var parsedUrl = url.parse(req.url, true);
+  if (parsedUrl.pathname == "/toggle-backtrace") {
+      monitor.backtrace = ! monitor.backtrace;
+      res.end('Toggling backtrace to ' + monitor.backtrace);
+  }
+  else if (parsedUrl.pathname == "/fib") {
+    var param = parsedUrl.query.n || 20;
+    var result = fib(param);
+    res.end('Finished calculating fibonacci(' + param + ') = ' + result );
+  }
+  else {
+    res.end('I am being monitored\n');
+  }
   //send health info
   process.monitor.setHealthStatus(false,0);
 }).listen(2000);


### PR DESCRIPTION
Primarily, this patch eliminates the frequent `Process received SIGHUP` messages from this module.

The fix ensures that in the `DebugEventListener`, we only consider Debugger events which correspond to the Debug::DebugBreak() command which we call at signal handler time.

Prior to this, the install DebugEventListener would get event callbacks from the v8 Debugger API whenever any event of potential interest to a debugger would occur, e.g. `BeforeCompileScript`, `AfterCompileScript` as seen here:

https://github.com/v8/v8/blob/1735e029d3ee2dbf940c4399d581a730bda59902/include/v8-debug.h#L16

In addition, as a side-effect, I've also added a getter/setter for a `backtrace` property on the `monitr.exports` such that you can enable or disable whether a backtrace is printed.

A demonstration of this is given in the accompanying `monitor_me.js` script.
