### PR TITLE
Add process.monitor.gc.{count,elapsed} getters

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -8,10 +8,13 @@ var EventEmitter = require('events').EventEmitter,
     net = require('net'),
     util = require('util');
 
-
 var reqCounter, //Singleton instance to monitor requests, connections and data transferred
     healthStatus; //Singleton instance to monitor status of app
 
+// Initialize an empty monitor object that hangs off the global
+// nodejs process object.  Functions get added to this during
+// initialization
+process.monitor = process.monitor || {};
 
 function ReqCounter() {
     this._requests = 0;
@@ -199,8 +202,6 @@ function setupListenHook() {
   };
 }
 
-process.monitor = process.monitor || {};
-
 // Set up listeners to count metrics
 setupListenHook();
 setupReqCounter();
@@ -211,8 +212,10 @@ setupHealthStatus();
 // This has the start and stop methods to control monitoring
 var monitor;
 monitor = module.exports = require('bindings')('monitor.node');
-// Adding this function to enable adding new handles to monitor
-// In case of applications where module is loaded after the server starts listening
+
+// addServer is needed to allow adding new request handles to monitor
+// in applications where this module is loaded after the server
+// starts listening
 module.exports.addServer = function(server) {
     reqCounter.addServer(server);
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   "main": "./lib/monitor.js",
   "scripts": {
     "pretest": "jshint --config ./node_modules/yui-lint/jshint.json ./lib/",
-    "test": "istanbul cover --print both vows -- --spec ./tests/*.js"
+    "test": "node --expose-gc `which istanbul` cover --print both vows -- --spec ./tests/*.js"
   }
 }

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -56,10 +56,13 @@ private:
     CpuUsage currentUsage_;
 };
 
+/** POD structure that contains GC statistics for a given "interval"
+ *  Times are in nanoseconds
+ */
 typedef struct {
     long unsigned int numCalls;
-    uint64_t cumulativeTime; //< in nanoseconds
-    uint64_t maxTime;        //< in nanoseconds
+    uint64_t cumulativeTime; //< total time of all collections (ns)
+    uint64_t maxTime;        //< max time of any single GC (ns)
 } GCStat;
 
 /**
@@ -75,51 +78,33 @@ class ScopedUVLock {
     ScopedUVLock();  //< can't create one of these without a reference to a mutex
 };
 
+
 /**
- * encapsulates garbage collection stats per "interval" where
- * interval is arbitrary time between calls to GetStats
- **/
-class GCUsage {
-public:
-    GCUsage();
-    ~GCUsage();
-
-    /** Returns garbage collection (GC) stats since last call to this function.
-     *  Also resets the counters in order to start a new interval of GC stats
-     */
-    const GCStat EndInterval();
-
-    /**
-     * start and stop events get called from v8 gc prologue/epilogue
-     **/
-    void Start();
-    void Stop();
-
- private:
-    GCStat     stats_;
-    uint64_t   startTime_;
-
-    // lock used to prevent reading/writing GCStat data structure at the same time
-    // by more than one thread
-    uv_mutex_t  lock_;
-
-    /* prevent copying/assigning */
-    GCUsage(const GCUsage&);
-    GCUsage& operator=(const GCUsage&);
-};
-
-
+ * General interface for tracking garbage collection statistics/usage
+ */
 class GCUsageTracker {
 public:
-    GCUsageTracker() {};
+    GCUsageTracker() : totalCollections_(0), totalElapsedTime_(0) {};
     ~GCUsageTracker() {};
 
-    inline GCUsage* GetGCUsage( const v8::GCType type ) {
-        int collector = v8GCTypeToIndex( type );
-        assert( collector >= 0 && collector < kNumGCTypes );
-
-        return &usage_[ v8GCTypeToIndex( type )];
+    //< Call this when a GC is starting
+    void StartGC( const v8::GCType type ) {
+        GetGCUsage(type).Start();
     }
+
+    //< call when GC is ending
+    void StopGC( const v8::GCType type ) {
+        uint64_t elapsed = GetGCUsage(type).Stop();
+        totalCollections_++;
+        totalElapsedTime_ += elapsed;
+    }
+
+    const GCStat EndInterval( const v8::GCType type ) {
+        return GetGCUsage( type ).EndInterval();
+    }
+
+    inline unsigned long int totalCollections() const { return totalCollections_; }
+    inline uint64_t totalElapsedTime() const { return totalElapsedTime_; }
 
     static const int kNumGCTypes = 2;  //< must match # of distinct v8::GCTypes in v8.h
 
@@ -134,7 +119,7 @@ public:
         case 0:  return v8::kGCTypeScavenge;
         case 1:  return v8::kGCTypeMarkSweepCompact;
         default:
-            return v8::kGCTypeAll;  //< with assertion above, this is unreachable
+            return v8::kGCTypeAll;  //< with assertion above, this should be unreachable
         }
     }
 
@@ -145,56 +130,100 @@ public:
         case 0:  return "scavenge";
         case 1:  return "marksweep";
         default:
-            return "unknown";  //< with assertion above, this is unreachable
+            return "unknown";  //< with assertion above, this should be unreachable
         }
     }
 
- private:
-    GCUsage  usage_[kNumGCTypes];
+private:
+    /**
+     * Encapsulates garbage collection stats per "reporting interval"
+     *
+     * \desc There may be multiple calls to Start/Stop during each
+     * interval.  We require a mutex lock to protect the stats_ data
+     * since this is written to/updated by the v8 Javascript thread at
+     * the same time as it may be read by the monitor thread
+     **/
+    class GCUsage {
+    public:
+        GCUsage();
+        ~GCUsage();
+
+        /** Returns garbage collection (GC) stats since last call to this function.
+         *  Also resets the counters in order to start a new interval of GC stats
+         */
+        const GCStat EndInterval();
+
+        /**
+         * start and stop events get called from v8 gc prologue/epilogue
+         **/
+        void     Start();
+        uint64_t Stop();   //< returns elapsed time as given by uv_hrtime()
+
+    private:
+        GCStat     stats_;
+        uint64_t   startTime_;
+
+        // lock used to prevent reading/writing GCStat data structure at the same time
+        // by more than one thread
+        uv_mutex_t  lock_;
+
+        /* prevent copying/assigning */
+        GCUsage(const GCUsage&);
+        GCUsage& operator=(const GCUsage&);
+    };
+
+    inline GCUsage& GetGCUsage( const v8::GCType type ) {
+        int collector = v8GCTypeToIndex( type );
+        assert( collector >= 0 && collector < kNumGCTypes );
+
+        return usage_[ v8GCTypeToIndex( type )];
+    }
+
+    GCUsage           usage_[kNumGCTypes];
+    long unsigned int totalCollections_;
+    uint64_t          totalElapsedTime_;
 };
 
 typedef struct {
-	
-	// time since last check
-	volatile struct timeval lastTime_;
-	
-	// time since last request
-	volatile struct timeval timeSinceLastRequest_;
-	
-	// last RPS
-	volatile int lastRPS_;
-	
-	// requests served
-	volatile float lastJiffiesPerReq_;
-	volatile float lastCpuPerReq_;
-	
-	// requests already served
-	volatile int lastRequests_;
-	
-	// delta between last check essentially req/per second
-	// if divided by curTime - lastTime
-	volatile int lastReqDelta_;
-	
-	// number of open requests
-	volatile int currentOpenReqs_;
-	
-	// number of open connections
-	volatile int currentOpenConns_;
-	
-	// Kb transfered since start
-	volatile float lastKBytesTransfered_;
-	volatile float lastKBytesSecond;
-	
-	// health status isDown
-	volatile bool healthIsDown_;
-	
-	// health status: statusCode
-	volatile int healthStatusCode_;
-	
-	volatile time_t healthStatusTimestamp_;
-	
-	volatile double pmem_;
-	
+    // time since last check
+    volatile struct timeval lastTime_;
+
+    // time since last request
+    volatile struct timeval timeSinceLastRequest_;
+
+    // last RPS
+    volatile int lastRPS_;
+
+    // requests served
+    volatile float lastJiffiesPerReq_;
+    volatile float lastCpuPerReq_;
+
+    // requests already served
+    volatile int lastRequests_;
+
+    // delta between last check essentially req/per second
+    // if divided by curTime - lastTime
+    volatile int lastReqDelta_;
+
+    // number of open requests
+    volatile int currentOpenReqs_;
+
+    // number of open connections
+    volatile int currentOpenConns_;
+
+    // Kb transfered since start
+    volatile float lastKBytesTransfered_;
+    volatile float lastKBytesSecond;
+
+    // health status isDown
+    volatile bool healthIsDown_;
+
+    // health status: statusCode
+    volatile int healthStatusCode_;
+
+    volatile time_t healthStatusTimestamp_;
+
+    volatile double pmem_;
 } Statistics;
 
 
@@ -223,16 +252,22 @@ public:
     v8::Isolate* getIsolate() { return isolate_; };
     GCUsageTracker& getGCUsageTracker() { return gcTracker_; }
 
-    void ipcInitialization();
     bool sendReport();
     void setStatistics();
   
     static NodeMonitor& getInstance();
 
 protected:
+    // Constructor - protected since external clients must use getInstance()
     NodeMonitor(v8::Isolate* isolate);
 
 private:
+    void InitializeIPC();
+    void InitializeProcessMonitorGCObject(); //< Install process.monitor.gc
+
+    // Member variables
+    bool running_;  //< have we already been started?
+
     time_t startTime;
   
     // Required to track CPU load asynchronously \todo no longer used?


### PR DESCRIPTION
Hang a gc object off process.monitor with readonly absolute values since
the monitr process is started of:

1. count: # of times GC stop-the-world events have occurred
2. elapsed: cumulative elapsed time in milliseconds spent in GC

By taking a snapshot of these values at two different times (t1 and t2),
application code can determine count and duration of GC events between
t1 and t2.