### PR TITLE
Use return value from origin stream.write

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -73,7 +73,7 @@ ReqCounter.prototype.registerEvents = function (server) {
                 if (data && data.length) {
                     that._transferred += data.length;
                 }
-                origWrite.apply(this, arguments);
+                return origWrite.apply(this, arguments);
             };
 
             stream.on('close', function () {


### PR DESCRIPTION
Writable.write returns a boolean value, and in this implementation that value is not being honored while overriding the stream.write. This leads to problem in modern implementations which are relying on this value to drain the buffer

https://nodejs.org/api/stream.html#writablewritechunk-encoding-callback

Updates the stream.write override to honor the original return value.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
