### PR TITLE
Convert native addon from NAN to N-API (hybrid) and modernize tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 language: node_js
 sudo: false
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.9
-      - g++-4.9
-env: CXX=g++-4.9 CC=gcc-4.9
 node_js:
-    - "10"
-    - "12"
-    - "13"
+    - "20"
+    - "22"
+    - "24"
+    - "26"

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,11 +3,15 @@
     {
       "target_name": "monitor",
       "sources": [ "src/monitor.cc" ],
-      "cflags_cc" : ["-fexceptions"],
-      "include_dirs" : [
-          "<(node_root_dir)/deps/cares/include",
-          "<!(node -e \"require('nan')\")"
-      ]
+      "include_dirs": [
+          "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "defines": [
+          "NAPI_VERSION=8",
+          "NAPI_CPP_EXCEPTIONS"
+      ],
+      "cflags_cc": [ "-fexceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ]
     }
   ]
 }

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,31 +1,26 @@
-const globals = require("globals");
-const js = require("@eslint/js");
+const js = require('@eslint/js');
+const globals = require('globals');
 
-const {
-    FlatCompat,
-} = require("@eslint/eslintrc");
+module.exports = [
+    js.configs.recommended,
+    {
+        files: ['examples/**/*.js', 'lib/**/*.js', 'tests/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'commonjs',
+            globals: {
+                ...globals.node,
+            },
+        },
+        rules: {
+            indent: ['error', 4, {
+                SwitchCase: 1,
+            }],
 
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
-});
-
-module.exports = [...compat.extends("eslint:recommended"), {
-    languageOptions: {
-        globals: {
-            ...globals.node,
+            'linebreak-style': ['error', 'unix'],
+            'no-console': 'off',
+            quotes: ['error', 'single'],
+            semi: ['error', 'always'],
         },
     },
-
-    rules: {
-        indent: ["error", 4, {
-            SwitchCase: 1,
-        }],
-
-        "linebreak-style": ["error", "unix"],
-        "no-console": "off",
-        quotes: ["error", "single"],
-        semi: ["error", "always"],
-    },
-}];
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monitr",
-  "version": "1.2.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monitr",
-      "version": "1.2.2",
+      "version": "1.5.0",
       "cpu": [
         "x64",
         "ia32"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,21 +16,17 @@
       ],
       "dependencies": {
         "bindings": "^1.5.0",
-        "nan": "^2.22.0"
+        "node-addon-api": "^8.8.0"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "^9.13.0",
-        "async": "^3.2.6",
-        "eslint": "^9.13.0",
-        "eslint-plugin-mocha": "^10.5.0",
-        "global": "^4.4.0",
-        "mocha": "^10.7.3",
-        "nyc": "^17.1.0",
-        "unix-dgram": "^2.0.6"
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.4.1",
+        "globals": "^17.6.0",
+        "nyc": "^18.0.0",
+        "unix-dgram": "^2.0.7"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -422,16 +418,18 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -439,7 +437,7 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -451,9 +449,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -461,107 +459,125 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.4",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.13.0.tgz",
-      "integrity": "sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.1.tgz",
-      "integrity": "sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.0.tgz",
-      "integrity": "sha512-2cbWIHbZVEweE853g8jymffCA+NCMiuqeECeBBLm8dg2oFdjuGJhgN4UAbI+6v0CKbbhvtXA4qV8YR5Ji86nmw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.5.tgz",
-      "integrity": "sha512-KSPA4umqSG4LHYRodq31VDwKAvaTF4xmVlzM8Aeh4PlU1JQ3IG0wiA8C25d3RQ9nJyM3mBHyI53K06VVL/oFFg==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.0",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -581,9 +597,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -764,24 +780,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
-      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -793,7 +816,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
@@ -803,7 +826,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "license": "MIT",
@@ -816,11 +839,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -830,16 +852,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -868,20 +880,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/append-transform": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
@@ -897,44 +895,10 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -946,35 +910,27 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.24.2",
@@ -1025,16 +981,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -1066,81 +1012,14 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
       }
     },
     "node_modules/color-convert": {
@@ -1170,13 +1049,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -1185,9 +1057,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1250,22 +1122,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
-      "dev": true
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.45",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.45.tgz",
@@ -1311,33 +1167,30 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.13.0.tgz",
-      "integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
-        "@eslint/config-array": "^0.18.0",
-        "@eslint/core": "^0.7.0",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.13.0",
-        "@eslint/plugin-kit": "^0.2.0",
-        "@humanfs/node": "^0.16.5",
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.1.0",
-        "eslint-visitor-keys": "^4.1.0",
-        "espree": "^10.2.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1347,17 +1200,15 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1371,125 +1222,50 @@
         }
       }
     },
-    "node_modules/eslint-plugin-mocha": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.5.0.tgz",
-      "integrity": "sha512-F2ALmQVPT1GoP27O1JTZGrV9Pqg8k79OeIuvw63UxMtQKREZtmkK1NFgkZQ2TW7L2JSSFKHFPTtHu5z8R9QNRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-utils": "^3.0.0",
-        "globals": "^13.24.0",
-        "rambda": "^7.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-mocha/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-mocha/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/eslint-scope": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.1.0.tgz",
-      "integrity": "sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
-      "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.2.0.tgz",
-      "integrity": "sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.12.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.1.0"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1510,9 +1286,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1524,7 +1300,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1537,10 +1313,9 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -1557,14 +1332,13 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
@@ -1594,19 +1368,6 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
@@ -1641,16 +1402,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -1725,28 +1476,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1777,27 +1506,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1811,44 +1519,10 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1892,16 +1566,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -1911,29 +1575,12 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -1948,42 +1595,9 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -2021,26 +1635,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -2061,22 +1655,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-windows": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true,
       "license": "MIT",
@@ -2132,21 +1713,19 @@
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
-      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/istanbul-lib-processinfo/-/istanbul-lib-processinfo-3.0.1.tgz",
+      "integrity": "sha512-s3mX05h5wGZeScG6XnOanygPh4SJu5ujMc9YbvpnLGXWy1cRiGbp0NdVcjHxgoZt3WfQppfBsa0y+gWdYJ2pGQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "archy": "^1.0.0",
         "cross-spawn": "^7.0.3",
         "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "uuid": "^8.3.2"
+        "rimraf": "^6.1.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": "20 || >=22"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -2216,19 +1795,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
@@ -2251,7 +1817,7 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
@@ -2323,30 +1889,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2383,101 +1925,28 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
-      "dev": true,
-      "dependencies": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mocha": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
-      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.3",
-        "browser-stdout": "^1.3.1",
-        "chokidar": "^3.5.3",
-        "debug": "^4.3.5",
-        "diff": "^5.2.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-up": "^5.0.0",
-        "glob": "^8.1.0",
-        "he": "^1.2.0",
-        "js-yaml": "^4.1.0",
-        "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
-        "ms": "^2.1.3",
-        "serialize-javascript": "^6.0.2",
-        "strip-json-comments": "^3.1.1",
-        "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9",
-        "yargs-unparser": "^2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha.js"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2491,6 +1960,7 @@
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
       "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -2499,6 +1969,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -2520,22 +1999,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/nyc": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
-      "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/nyc/-/nyc-18.0.0.tgz",
+      "integrity": "sha512-G5UyHinFkB1BxqGTrmZdB6uIYH0+v7ZnVssuflUDi+J+RhKWyAhRT1RCehBSI6jLFLuUUgFDyLt49mUtdO1XeQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.2",
@@ -2546,11 +2014,11 @@
         "find-up": "^4.1.0",
         "foreground-child": "^3.3.0",
         "get-package-type": "^0.1.0",
-        "glob": "^7.1.6",
+        "glob": "^13.0.6",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
         "istanbul-lib-instrument": "^6.0.2",
-        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-processinfo": "^3.0.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
@@ -2559,17 +2027,17 @@
         "p-map": "^3.0.0",
         "process-on-spawn": "^1.0.0",
         "resolve-from": "^5.0.0",
-        "rimraf": "^3.0.0",
+        "rimraf": "^6.1.3",
         "signal-exit": "^3.0.2",
-        "spawn-wrap": "^2.0.0",
-        "test-exclude": "^6.0.0",
+        "spawn-wrap": "^3.0.0",
+        "test-exclude": "^8.0.0",
         "yargs": "^15.0.2"
       },
       "bin": {
         "nyc": "bin/nyc.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nyc/node_modules/cliui": {
@@ -2599,22 +2067,18 @@
       }
     },
     "node_modules/nyc/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "13.0.6",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2631,6 +2095,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/nyc/node_modules/p-limit": {
@@ -2660,6 +2134,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nyc/node_modules/resolve-from": {
@@ -2731,16 +2221,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2793,7 +2273,7 @@
     },
     "node_modules/p-map": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/p-map/-/p-map-3.0.0.tgz",
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
       "dev": true,
       "license": "MIT",
@@ -2830,18 +2310,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/parent-module": {
+    "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -2851,16 +2325,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -2879,19 +2343,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -2972,16 +2423,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -2997,42 +2438,12 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/rambda": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
-      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/release-zalgo": {
@@ -3065,75 +2476,68 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "version": "6.1.3",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "13.0.6",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -3146,16 +2550,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-blocking": {
@@ -3206,16 +2600,17 @@
       }
     },
     "node_modules/spawn-wrap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/spawn-wrap/-/spawn-wrap-3.0.0.tgz",
+      "integrity": "sha512-z+s5vv4KzFPJVddGab0xX2n7kQPGMdNUX5l9T8EJqsXdKTWpcxmAqWHpsgHEXoC1taGBCc7b79bi62M5kdbrxQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
+        "cross-spawn": "^7.0.6",
         "foreground-child": "^2.0.0",
         "is-windows": "^1.0.2",
         "make-dir": "^3.0.0",
-        "rimraf": "^3.0.0",
+        "rimraf": "^6.1.3",
         "signal-exit": "^3.0.2",
         "which": "^2.0.1"
       },
@@ -3225,10 +2620,9 @@
     },
     "node_modules/spawn-wrap/node_modules/foreground-child": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/foreground-child/-/foreground-child-2.0.0.tgz",
       "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
@@ -3282,19 +2676,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3309,60 +2690,62 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "13.0.6",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
-      "license": "MIT"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+    "node_modules/test-exclude/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "is-number": "^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/type-check": {
@@ -3399,15 +2782,14 @@
       }
     },
     "node_modules/unix-dgram": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.6.tgz",
-      "integrity": "sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/unix-dgram/-/unix-dgram-2.0.7.tgz",
+      "integrity": "sha512-pWaQorcdxEUBFIKjCqqIlQaOoNVmchyoaNAJ/1LwyyfK2XSxcBhgJNiSE8ZRhR0xkNGyk4xInt1G03QPoKXY5A==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "ISC",
       "dependencies": {
         "bindings": "^1.5.0",
-        "nan": "^2.16.0"
+        "nan": "^2.20.0"
       },
       "engines": {
         "node": ">=0.10.48"
@@ -3446,22 +2828,12 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npm.ouryahoo.com:4443/npm/api/npm/npm/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {
@@ -3497,38 +2869,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -3542,93 +2882,12 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -38,26 +38,22 @@
     }
   ],
   "engines": {
-    "node": ">=0.12"
+    "node": ">=20"
   },
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.22.0"
+    "node-addon-api": "^8.8.0"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.1.0",
-    "@eslint/js": "^9.13.0",
-    "async": "^3.2.6",
-    "eslint": "^9.13.0",
-    "eslint-plugin-mocha": "^10.5.0",
-    "global": "^4.4.0",
-    "mocha": "^10.7.3",
-    "nyc": "^17.1.0",
-    "unix-dgram": "^2.0.6"
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.4.1",
+    "globals": "^17.6.0",
+    "nyc": "^18.0.0",
+    "unix-dgram": "^2.0.7"
   },
   "main": "./lib/monitor.js",
   "scripts": {
-    "pretest": "eslint examples/*.js lib/*js tests/*.js",
-    "test": "nyc --report-dir artifacts/coverage --reporter text-summary --reporter lcov --cache=false mocha -n expose-gc tests/test-monitor.js"
+    "pretest": "eslint examples/*.js lib/*.js tests/*.js",
+    "test": "nyc --report-dir artifacts/coverage --reporter text-summary --reporter lcov --cache=false node --expose-gc tests/test-monitor.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monitr",
   "description": "Node process monitoring tool",
-  "version": "1.2.2",
+  "version": "1.5.0",
   "author": "Rohini Harendra <rohini.raghav@gmail.com>",
   "contributors": [
     {

--- a/src/monitor.cc
+++ b/src/monitor.cc
@@ -19,9 +19,6 @@
 #include <fstream>
 #include <algorithm>
 
-// v8 compatibility templates
-#include "nan.h"
-
 #include "monitor.h"
 
 #ifdef __APPLE__
@@ -32,12 +29,7 @@
     extern char **environ;
 #endif
 
-#define THROW_BAD_ARGS() \
-    Nan::ThrowError(Exception::TypeError(Nan::New<String>(__FUNCTION__).ToLocalChecked()));
-
-
 using namespace std;
-using namespace v8;
 
 // This is the default IPC path where the stats are written to
 // Could use the setter method to change this
@@ -63,40 +55,23 @@ namespace ynode {
 // our singleton instance
 NodeMonitor* NodeMonitor::instance_ = NULL;
 
-// some utility functions to make code cleaner
-static inline v8::Local<v8::String> v8_str( const char* s ) {
-    Nan::MaybeLocal<v8::String> s_maybe = Nan::New<v8::String>(s);
-    return s_maybe.ToLocalChecked();
-}
-
-static inline v8::Local<v8::Value> getObjectProperty(const v8::Local<v8::Object>& object,
-                                                     const char* key) {
-    v8::Local<v8::String> keyString = v8_str(key);
-    Nan::MaybeLocal<v8::Value> value = Nan::Get(object, keyString);
-    if (value.IsEmpty()) {
-        return Nan::Undefined();
-    }
-    return value.ToLocalChecked();
-}
-
 /**
  * obtain reference to process.monitor from global object
  *
  * Preconditions:  process.monitor exists and is an object
+ *
+ * Must be called on the JS thread (i.e. inside a N-API callback).
  **/
-static v8::Local<v8::Object> getProcessMonitor() {
-    Nan::EscapableHandleScope scope;
-
-    v8::Local<v8::Object> global = Nan::GetCurrentContext()->Global();
-    v8::Local<v8::Value> process = getObjectProperty( global, "process" );
-    assert( Nan::Undefined() != process && process->IsObject());
+static Napi::Object getProcessMonitor(Napi::Env env) {
+    Napi::Object global = env.Global();
+    Napi::Value process = global.Get("process");
+    assert(process.IsObject());
 
     // monitr javascript interface library must create process.monitor
+    Napi::Value monitor = process.As<Napi::Object>().Get("monitor");
+    assert(monitor.IsObject());
 
-    v8::Local<v8::Value> monitor = getObjectProperty(process.As<v8::Object>(), "monitor" );
-    assert( Nan::Undefined() != monitor && monitor->IsObject());
-
-    return scope.Escape(monitor.As<v8::Object>());
+    return monitor.As<Napi::Object>();
 }
 
 
@@ -157,20 +132,20 @@ static void doSleep(int ms) {
 
 static void Interrupter(v8::Isolate* isolate, void *data) {
     const int kMaxFrames = 64;
-    v8::Local<StackTrace> stack = v8::StackTrace::CurrentStackTrace(isolate, kMaxFrames);
+    v8::Local<v8::StackTrace> stack = v8::StackTrace::CurrentStackTrace(isolate, kMaxFrames);
     const int frameCount = stack->GetFrameCount();
 
     fprintf(stderr, "Interrupted: (frames: %d of %d)\n", std::min(frameCount, kMaxFrames), frameCount);
     for (int i = 0; i < stack->GetFrameCount(); ++i ) {
-        v8::Local<StackFrame> frame = stack->GetFrame(
+        v8::Local<v8::StackFrame> frame = stack->GetFrame(
 #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION >= 7)
              isolate, 
 #endif
              i );
         int line = frame->GetLineNumber();
         int col = frame->GetColumn();
-        Nan::Utf8String fn(frame->GetFunctionName());
-        Nan::Utf8String script(frame->GetScriptName());
+        v8::String::Utf8Value fn(isolate, frame->GetFunctionName());
+        v8::String::Utf8Value script(isolate, frame->GetScriptName());
 
         fprintf(stderr, "    at %s (%s:%d:%d)\n",
                 fn.length() == 0 ? "<anonymous>" : *fn, *script, line, col);
@@ -189,7 +164,7 @@ void* monitorNodeThread(void *arg) {
 
     NodeMonitor& monitor = NodeMonitor::getInstance();
     doSleep(REPORT_INTERVAL_MS);
-    while (true) {
+    while (!monitor.isStopRequested()) {
         if (hup_fired) {
             siginfo_t *siginfo = &savedSigInfo;
             fprintf(stderr, "Process %d received SIGHUP from pid %d\n", getpid(), siginfo->si_pid);
@@ -208,66 +183,61 @@ void* monitorNodeThread(void *arg) {
                 errorCounter = 0;
             }
         }
+        if (monitor.isStopRequested()) {
+            break;
+        }
         doSleep(REPORT_INTERVAL_MS);
     }
-    exit(0);
+    return NULL;
 }
 
-// Invoked when woken by monitr pthread via async_send
-NAUV_WORK_CB(UpdateStatisticsCallback) {
-    NodeMonitor::getInstance().setStatistics();
+// N-API getter for process.monitor.gc.count
+static Napi::Value GetterGCCount(const Napi::CallbackInfo& info) {
+    GCUsageTracker& tracker = NodeMonitor::getInstance().getGCUsageTracker();
+    return Napi::Number::New(info.Env(), static_cast<double>(tracker.totalCollections()));
 }
 
-static NAN_GETTER(GetterGCCount) {
-    NodeMonitor& monitor = NodeMonitor::getInstance();
-    GCUsageTracker& tracker = monitor.getGCUsageTracker();
-
-    info.GetReturnValue().Set(Nan::New<Number>(tracker.totalCollections()));
+// N-API getter for process.monitor.gc.elapsed (milliseconds)
+static Napi::Value GetterGCElapsed(const Napi::CallbackInfo& info) {
+    GCUsageTracker& tracker = NodeMonitor::getInstance().getGCUsageTracker();
+    return Napi::Number::New(info.Env(), tracker.totalElapsedTime() / (1000.0 * 1000.0));
 }
 
-static NAN_GETTER(GetterGCElapsed) {
-    NodeMonitor& monitor = NodeMonitor::getInstance();
-    GCUsageTracker& tracker = monitor.getGCUsageTracker();
-
-    info.GetReturnValue().Set(Nan::New<Number>(tracker.totalElapsedTime() / (1000.0 * 1000.0) ));
+// V8 GC prologue/epilogue callbacks.  N-API has no abstraction for these,
+// so we register them directly on the isolate (the "hybrid" part).
+static void startGC(v8::Isolate* /*isolate*/, v8::GCType type, v8::GCCallbackFlags /*flags*/) {
+    NodeMonitor::getInstance().getGCUsageTracker().StartGC(type);
 }
 
-static NAN_GC_CALLBACK(startGC) {
-    NodeMonitor& monitor = NodeMonitor::getInstance();
-    GCUsageTracker& tracker = monitor.getGCUsageTracker();
-    tracker.StartGC(type);
+static void stopGC(v8::Isolate* /*isolate*/, v8::GCType type, v8::GCCallbackFlags /*flags*/) {
+    NodeMonitor::getInstance().getGCUsageTracker().StopGC(type);
 }
 
-static NAN_GC_CALLBACK(stopGC) {
-    NodeMonitor& monitor = NodeMonitor::getInstance();
-    GCUsageTracker& tracker = monitor.getGCUsageTracker();
-    tracker.StopGC(type);
+void NodeMonitor::InstallGCEventCallbacks() {
+    isolate_->AddGCPrologueCallback(startGC);
+    isolate_->AddGCEpilogueCallback(stopGC);
 }
 
-static void InstallGCEventCallbacks() {
-    Nan::AddGCPrologueCallback(startGC);
-    Nan::AddGCEpilogueCallback(stopGC);
-}
-
-static void UninstallGCEventCallbacks() {
-    Nan::RemoveGCPrologueCallback(startGC);
-    Nan::RemoveGCEpilogueCallback(stopGC);
+void NodeMonitor::UninstallGCEventCallbacks() {
+    isolate_->RemoveGCPrologueCallback(startGC);
+    isolate_->RemoveGCEpilogueCallback(stopGC);
 }
 
 /**
  * Set up the singleton instance variable
  */
-void NodeMonitor::Initialize(v8::Isolate* isolate) {
+void NodeMonitor::Initialize(Napi::Env env) {
 
     // only one instance is allowed per process
     // \todo change this to be one per *isolate*
     if (instance_) {
         return;
     }
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
     assert(0 != isolate);
     instance_ = new NodeMonitor(isolate); // calls protected constructor
 
-    instance_->InitializeProcessMonitorGCObject();
+    instance_->InitializeProcessMonitorGCObject(env);
 }
 
 /**
@@ -300,27 +270,22 @@ void NodeMonitor::InitializeIPC() {
  * Set up process.monitor.gc object and accessors for count/elapsed
  * These can be read from Javascript user code space
  **/
-void NodeMonitor::InitializeProcessMonitorGCObject() {
-    Nan::HandleScope scope;
+void NodeMonitor::InitializeProcessMonitorGCObject(Napi::Env env) {
+    Napi::HandleScope scope(env);
 
-    v8::Local<v8::Object> monitor = getProcessMonitor();
+    Napi::Object monitor = getProcessMonitor(env);
 
     // Create an object called "gc" with accessors for count/elapsed
     // * count is # of times GC has run in this process
     // * elapsed is the total duration for GC in milliseconds
     //
-    // This is a "plain-old-data" object - i.e. it does not have
-    // any prototype and does not have a constructor function.
-    // For this reason, we don't need any FunctionTemplate etc.
-    // In addition, we only ever have one object per process, so
-    // an ObjectTemplate seems overkill as well.
-    {
-        v8::Local<v8::Object> gcObj = Nan::New<v8::Object>();
-        Nan::Set( monitor.As<v8::Object>(), v8_str("gc"), gcObj );
-
-        Nan::SetAccessor( gcObj, v8_str("count"), GetterGCCount, 0 );
-        Nan::SetAccessor( gcObj, v8_str("elapsed"), GetterGCElapsed, 0 );
-    }
+    // The accessors are read-only (getter, no setter).
+    Napi::Object gcObj = Napi::Object::New(env);
+    gcObj.DefineProperties({
+        Napi::PropertyDescriptor::Accessor<GetterGCCount>("count"),
+        Napi::PropertyDescriptor::Accessor<GetterGCElapsed>("elapsed"),
+    });
+    monitor.Set("gc", gcObj);
 }
 
 /**
@@ -330,7 +295,7 @@ void NodeMonitor::InitializeProcessMonitorGCObject() {
  * the monitor is started.
  * Spawns a thread to monitor stats every REPORT_INTERVAL_MS
  */
-void NodeMonitor::Start() {
+void NodeMonitor::Start(Napi::Env env) {
 
     assert( 0 != instance_ );
 
@@ -339,6 +304,7 @@ void NodeMonitor::Start() {
         return;
     }
     running_ = true;
+    stopRequested_ = false;
 
     InstallGCEventCallbacks();
     InitializeIPC();
@@ -362,12 +328,21 @@ void NodeMonitor::Start() {
     }
 
 
-    // Tell libuv to execute our callback function (updateStatistics)
-    // inside the libuv default event loop (the same as used by nodejs
-    // - i.e. inside the v8 Javascript context) when "signalled" by the
-    // monitr pthread via an uv_async_send
-    uv_async_init(uv_default_loop(), &check_loop_, &UpdateStatisticsCallback);
-    uv_unref((uv_handle_t*) &check_loop_);
+    // Create a thread-safe function so the monitr pthread can schedule
+    // setStatistics() back onto the JS thread.  This is the modern N-API
+    // replacement for the previous uv_async_t handle + uv_async_send.
+    //
+    // The JS callback is a no-op: the real work happens in the native
+    // [](Napi::Env, Napi::Function) callback passed to NonBlockingCall().
+    tsfn_ = Napi::ThreadSafeFunction::New(
+        env,
+        Napi::Function::New(env, [](const Napi::CallbackInfo&) {}),
+        "monitr",
+        0,   // unlimited queue
+        1);  // one producer thread (the monitr pthread)
+
+    // Don't let the monitor keep the event loop (and hence the process) alive.
+    tsfn_.Unref(env);
 
     // Go ahead and create the monitr pthread
     {
@@ -395,15 +370,15 @@ void NodeMonitor::Start() {
  * at the conclusion of the next reporting interval (REPORT_INTERVAL_MS)
  * by the monitr pthread
  **/
-void NodeMonitor::setStatistics() {
+void NodeMonitor::setStatistics(Napi::Env env) {
 
     pending_ = 0;
     loop_timestamp_ = uv_hrtime();
     loop_count_++;
 
-    {   // obtain heap memory usage ratio
+    {   // obtain heap memory usage ratio (V8 direct - no N-API equivalent)
         v8::HeapStatistics v8stats;
-        Nan::GetHeapStatistics(&v8stats);
+        isolate_->GetHeapStatistics(&v8stats);
 
         stats_.pmem_ = (v8stats.used_heap_size() / (double) v8stats.total_heap_size());
     }
@@ -417,7 +392,7 @@ void NodeMonitor::setStatistics() {
         cpuTrackerSync_.GetCurrent(&ucpu, &scpu, &uticks, &sticks);
 
         // Get total number of requests since monitr started
-        unsigned int totalReqs = getIntFunction("getTotalRequestCount");
+        unsigned int totalReqs = getIntFunction(env, "getTotalRequestCount");
         unsigned int reqDelta = totalReqs - stats_.lastRequests_;
 
         // Update the number of requests processed
@@ -448,21 +423,21 @@ void NodeMonitor::setStatistics() {
         stats_.lastRPS_ = (int) (stats_.lastReqDelta_ / ( timeDelta / 1000.0));
 
         // Get currently open requests
-        stats_.currentOpenReqs_ = getIntFunction("getRequestCount");
+        stats_.currentOpenReqs_ = getIntFunction(env, "getRequestCount");
 
         // currently open connections
-        stats_.currentOpenConns_ = getIntFunction("getOpenConnections");
+        stats_.currentOpenConns_ = getIntFunction(env, "getOpenConnections");
 
         // Kb of transferred data
-        float dataTransferred = ((float) (getIntFunction("getTransferred"))) / 1024;
+        float dataTransferred = ((float) (getIntFunction(env, "getTransferred"))) / 1024;
 
         stats_.lastKBytesSecond = (dataTransferred - stats_.lastKBytesTransfered_) / (((double) timeDelta) / 1000);
         stats_.lastKBytesTransfered_ = dataTransferred;
     }
 
-    stats_.healthIsDown_ = getBooleanFunction("isDown");
-    stats_.healthStatusCode_ = getIntFunction("getStatusCode");
-    stats_.healthStatusTimestamp_ = (time_t) getIntFunction("getStatusTimestamp");
+    stats_.healthIsDown_ = getBooleanFunction(env, "isDown");
+    stats_.healthStatusCode_ = getIntFunction(env, "getStatusCode");
+    stats_.healthStatusTimestamp_ = (time_t) getIntFunction(env, "getStatusTimestamp");
 
 }
 
@@ -577,23 +552,18 @@ void CpuUsageTracker::CalculateCpuUsage(CpuUsage* cur_usage,
         - (last_usage->stime_ticks + last_usage->cstime_ticks));
 }
 
-Local<Value> callFunction(const char* funcName) {
-    Nan::EscapableHandleScope scope;
-
-    v8::Local<v8::Object> monitor = getProcessMonitor();
+// Invoke a zero-arg function on process.monitor by name.
+// Returns the function's result, or null if it doesn't exist.
+// Must be called on the JS thread.
+static Napi::Value callFunction(Napi::Env env, const char* funcName) {
+    Napi::Object monitor = getProcessMonitor(env);
 
     // Does funcName function exist on process.monitor object?
-    Nan::MaybeLocal<v8::Value> fval = Nan::Get(monitor, v8_str(funcName));
-    if (!fval.IsEmpty() && fval.ToLocalChecked()->IsFunction()) {
-        v8::Local<v8::Object> global = Nan::GetCurrentContext()->Global();
-        Nan::Callback callback( fval.ToLocalChecked().As<v8::Function>() );
-
-        Local<v8::Value> result = callback(global, 0, 0 );
-
-        return scope.Escape(result);
+    Napi::Value fval = monitor.Get(funcName);
+    if (fval.IsFunction()) {
+        return fval.As<Napi::Function>().Call(env.Global(), {});
     }
-    return Nan::Null();
-
+    return env.Null();
 }
 
 
@@ -667,28 +637,21 @@ const GCStat GCUsageTracker::GCUsage::EndInterval() {
 }
 
 // calls a Javascript function which returns an integer result
-int NodeMonitor::getIntFunction(const char* funcName) {
-    Nan::HandleScope scope;
-    Local<Value> res = callFunction(funcName);
-    if (res->IsNumber()) {
-        uint32_t value = res->Uint32Value(Nan::GetCurrentContext()).FromJust();
-        return value;
+int NodeMonitor::getIntFunction(Napi::Env env, const char* funcName) {
+    Napi::HandleScope scope(env);
+    Napi::Value res = callFunction(env, funcName);
+    if (res.IsNumber()) {
+        return res.As<Napi::Number>().Uint32Value();
     }
     return 0;
 }
 
 // calls a Javascript function which returns a boolean result
-bool NodeMonitor::getBooleanFunction(const char* funcName) {
-    Nan::HandleScope scope;
-    Local<Value> res = callFunction(funcName);
-    if (res->IsBoolean()) {
-#if V8_MAJOR_VERSION > 6 // after Node.js 10
-        v8::Isolate* isolate = v8::Isolate::GetCurrent();
-        bool value = res->BooleanValue(isolate);
-#else
-        bool value = res->BooleanValue(Nan::GetCurrentContext()).FromJust();
-#endif
-        return value;
+bool NodeMonitor::getBooleanFunction(Napi::Env env, const char* funcName) {
+    Napi::HandleScope scope(env);
+    Napi::Value res = callFunction(env, funcName);
+    if (res.IsBoolean()) {
+        return res.As<Napi::Boolean>().Value();
     }
     return false;
 }
@@ -886,8 +849,12 @@ bool NodeMonitor::sendReport() {
         pending_ = 1;
     }
 
-    // notify libuv that it should run the UpdateStatistics callback
-    uv_async_send(&check_loop_);
+    // Schedule setStatistics() to run on the JS thread.  This replaces the
+    // old uv_async_send(): the TSFN marshals us back onto the event loop
+    // where it is safe to call into V8/JS.
+    tsfn_.NonBlockingCall([](Napi::Env env, Napi::Function /*jsCallback*/) {
+        NodeMonitor::getInstance().setStatistics(env);
+    });
     return (rc != -1);
 }
 
@@ -899,10 +866,34 @@ bool NodeMonitor::sendReport() {
 void NodeMonitor::Stop() {
     assert( 0 != instance_ );
 
+    if ( !running_ ) {
+        return;
+    }
+
     UninstallGCEventCallbacks();
 
-    pthread_cancel(tmonitor_);
+    // Ask the monitor thread to exit and wake it from its pselect() sleep
+    // by writing to the self-pipe, then wait for it to finish.
+    stopRequested_ = true;
+    if (sigpipefd_w != -1) {
+        char c = 0;
+        ssize_t rc = write(sigpipefd_w, &c, 1);
+        (void) rc;  // best-effort wakeup
+    }
+    pthread_join(tmonitor_, NULL);
+
+    // The producer thread is gone, so it is now safe to release the TSFN.
+    if (tsfn_) {
+        tsfn_.Release();
+        tsfn_ = Napi::ThreadSafeFunction();
+    }
+
     close(ipcSocket_);
+    ipcSocket_ = -1;
+
+    // Close the self-pipe so a subsequent Start() can recreate it cleanly.
+    if (sigpipefd_r != -1) { close(sigpipefd_r); sigpipefd_r = -1; }
+    if (sigpipefd_w != -1) { close(sigpipefd_w); sigpipefd_w = -1; }
 
     running_ = false;
 }
@@ -912,6 +903,7 @@ void NodeMonitor::Stop() {
  */
 NodeMonitor::NodeMonitor(v8::Isolate* isolate) :
     running_(false),
+    stopRequested_(false),
     startTime(0),
     gcTracker_(),
     tmonitor_((pthread_t) NULL),
@@ -949,53 +941,50 @@ static void SignalHangupActionHandler(int signo, siginfo_t* siginfo,  void* cont
 
 // Javascript interface routines
 // Javascript getter/setters
-static NAN_GETTER(GetterIPCMonitorPath) {
-    info.GetReturnValue().Set(Nan::New<String>(_ipcMonitorPath.c_str()).ToLocalChecked());
+static Napi::Value GetterIPCMonitorPath(const Napi::CallbackInfo& info) {
+    return Napi::String::New(info.Env(), _ipcMonitorPath);
 }
 
 
 // methods that can be called from Javascript
-static NAN_METHOD(SetterIPCMonitorPath) {
+static Napi::Value SetterIPCMonitorPath(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
     if (info.Length() < 1 ||
-        (!info[0]->IsString() && !info[0]->IsUndefined() && !info[0]->IsNull())) {
-        THROW_BAD_ARGS();
+        (!info[0].IsString() && !info[0].IsUndefined() && !info[0].IsNull())) {
+        Napi::TypeError::New(env, "setIpcMonitorPath: expected a string path")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
     }
-    Nan::Utf8String ipcMonitorPath(info[0]);
-    _ipcMonitorPath = *ipcMonitorPath;
+    if (info[0].IsString()) {
+        _ipcMonitorPath = info[0].As<Napi::String>().Utf8Value();
+    }
+    return env.Undefined();
 }
 
-static NAN_METHOD(StartMonitor) {
-    NodeMonitor::getInstance().Start();
+static Napi::Value StartMonitor(const Napi::CallbackInfo& info) {
+    NodeMonitor::getInstance().Start(info.Env());
+    return info.Env().Undefined();
 }
 
-static NAN_METHOD(StopMonitor) {
+static Napi::Value StopMonitor(const Napi::CallbackInfo& info) {
     NodeMonitor::getInstance().Stop();
+    return info.Env().Undefined();
 }
 
 
 // main module initialization
-NAN_MODULE_INIT(init) {
-    // target is defined in the NAN_MODULE_INIT macro as ADDON_REGISTER_FUNCTION_ARGS_TYPE
-    //  -- i.e. v8::Local<v8::Object> for nodejs-3.x and up,
-    // but v8::Handle<v8::Object> for nodejs-0.12.0
+static Napi::Object init(Napi::Env env, Napi::Object exports) {
+    exports.DefineProperty(
+        Napi::PropertyDescriptor::Accessor<GetterIPCMonitorPath>("ipcMonitorPath"));
+    exports.Set("setIpcMonitorPath", Napi::Function::New(env, SetterIPCMonitorPath));
+    exports.Set("start", Napi::Function::New(env, StartMonitor));
+    exports.Set("stop", Napi::Function::New(env, StopMonitor));
 
-#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
-    Local<Object> exports = Nan::New<Object>(target);
-#else
-    Local<Object> exports = target;
-#endif
-
-    Nan::SetAccessor( exports, Nan::New("ipcMonitorPath").ToLocalChecked(),
-                      GetterIPCMonitorPath, 0, v8::Local<v8::Value>(),
-                      v8::DEFAULT, v8::DontDelete );
-    Nan::Export( exports, "setIpcMonitorPath", SetterIPCMonitorPath);
-    Nan::Export( exports, "start", StartMonitor);
-    Nan::Export( exports, "stop", StopMonitor);
-
-    NodeMonitor::Initialize(v8::Isolate::GetCurrent());
+    NodeMonitor::Initialize(env);
     RegisterSignalHandler(SIGHUP, SignalHangupActionHandler);
 
+    return exports;
 }
 
-NODE_MODULE(monitor, init)
+NODE_API_MODULE(monitor, init)
 }

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <string.h>
 #include <limits.h>
+#include <cassert>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ipc.h>
@@ -28,6 +29,14 @@
 #include <list>
 #include <string>
 #include <vector>
+
+// node-addon-api provides the stable N-API binding layer.  We still reach
+// directly into V8 (v8.h) and libuv (uv.h) for the handful of capabilities
+// N-API intentionally does not expose: GC prologue/epilogue callbacks,
+// heap statistics, and isolate interrupts / stack traces.
+#include <napi.h>
+#include <v8.h>
+#include <uv.h>
 
 namespace ynode {
 
@@ -237,13 +246,18 @@ typedef struct {
 class NodeMonitor {
 public:
     /** Initializes the singleton.  Do not call any other functions
-     * unless this function has been called first 
+     * unless this function has been called first
      */
-    static void Initialize(v8::Isolate* isolate);
-         
-    void Start();
+    static void Initialize(Napi::Env env);
+
+    void Start(Napi::Env env);
     void Stop();
     virtual ~NodeMonitor();
+
+    /** True once Stop() has requested the monitor thread to exit.
+     * Read by the monitor pthread to break out of its reporting loop.
+     */
+    bool isStopRequested() const { return stopRequested_; }
   
     /** Returns isolate which this NodeMonitor object is monitoring
      *
@@ -253,8 +267,8 @@ public:
     GCUsageTracker& getGCUsageTracker() { return gcTracker_; }
 
     bool sendReport();
-    void setStatistics();
-  
+    void setStatistics(Napi::Env env);
+
     static NodeMonitor& getInstance();
 
 protected:
@@ -263,10 +277,13 @@ protected:
 
 private:
     void InitializeIPC();
-    void InitializeProcessMonitorGCObject(); //< Install process.monitor.gc
+    void InitializeProcessMonitorGCObject(Napi::Env env); //< Install process.monitor.gc
+    void InstallGCEventCallbacks();    //< hook V8 GC prologue/epilogue
+    void UninstallGCEventCallbacks();  //< unhook V8 GC prologue/epilogue
 
     // Member variables
     bool running_;  //< have we already been started?
+    volatile bool stopRequested_; //< set by Stop() to break the monitor thread loop
 
     time_t startTime;
   
@@ -281,9 +298,11 @@ private:
     GCUsageTracker gcTracker_; //< keeps track of gc events
     pthread_t tmonitor_;    //< the pthread doing the monitoring
     v8::Isolate* isolate_;  //< the isolate this monitor is monitoring
-  
-    uv_async_t check_loop_;
-  
+
+    // Modern replacement for the old uv_async_t handle: the monitor pthread
+    // schedules setStatistics() back onto the JS thread via this TSFN.
+    Napi::ThreadSafeFunction tsfn_;
+
     volatile unsigned int loop_count_;
     volatile unsigned int last_loop_count_;
     volatile uint64_t loop_timestamp_;
@@ -296,8 +315,8 @@ private:
     struct msghdr msg_;
     int ipcSocket_;
   
-    static int getIntFunction(const char* funcName);
-    static bool getBooleanFunction(const char* funcName);
+    static int getIntFunction(Napi::Env env, const char* funcName);
+    static bool getBooleanFunction(Napi::Env env, const char* funcName);
 
     static NodeMonitor* instance_;  //< the singleton instance
 

--- a/tests/test-monitor.js
+++ b/tests/test-monitor.js
@@ -1,15 +1,14 @@
-/* global describe,it,before,after */
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const dgram = require('unix-dgram');
+const fsp = require('node:fs').promises;
+const http = require('node:http');
+const monitor = require('../lib/monitor');
 
-var assert = require('assert'),
-    async = require('async'),
-    dgram = require('unix-dgram'),
-    fs = require('fs'),
-    http = require('http'),
-    monitor = require('../lib/monitor');
-var defaultIpcMonitorPath = '/tmp/nodejs.mon',
-    ipcMonitorPath = '/tmp/nodejs-test-' + process.pid + '.mon';
+const defaultIpcMonitorPath = '/tmp/nodejs.mon';
+const ipcMonitorPath = '/tmp/nodejs-test-' + process.pid + '.mon';
 
-var expectedProperties = [
+const expectedProperties = [
     'cluster',
     'cpu',
     'cpuperreq',
@@ -31,16 +30,24 @@ var expectedProperties = [
     'utcstart',
 ];
 
-var expectedGCCollectors = [
+const expectedGCCollectors = [
     'marksweep',
     'scavenge',
 ];
 
-var expectedGCStatProperties = [
+const expectedGCStatProperties = [
     'count',
     'elapsed_ms',
     'max_ms',
 ];
+
+// Bind a unix datagram socket while temporarily clearing the umask so the
+// socket file is world-writable (the monitor sends to it from a C++ thread).
+function bindWithOpenUmask(socket, path) {
+    const um = process.umask(0);
+    socket.bind(path);
+    process.umask(um);
+}
 
 describe('monitr', function() {
     describe('our own monitor path', function() {
@@ -56,6 +63,7 @@ describe('monitr', function() {
             monitor.setIpcMonitorPath(ipcMonitorPath);
             monitor.start();
         });
+
         after(function() {
             monitor.stop();
         });
@@ -72,7 +80,7 @@ describe('monitr', function() {
             it('has count and elapsed properties', function() {
                 assert.equal(typeof process.monitor.gc.count, 'number');
                 assert.equal(typeof process.monitor.gc.elapsed, 'number');
-                function getSetter( obj, prop ) {
+                function getSetter(obj, prop) {
                     return Object.getOwnPropertyDescriptor(obj, prop).set;
                 }
                 assert.ok(undefined === getSetter(process.monitor.gc, 'count'));
@@ -88,63 +96,46 @@ describe('monitr', function() {
     });
 
     describe('message sent from a server', function() {
-        var server, port;
-        var socket;
-        var topic = {};
+        let server, port;
+        let socket;
+        const topic = {};
 
-        before(function(done) {
-            async.series([
-                (taskDone) => {
-                    monitor.setIpcMonitorPath(ipcMonitorPath);
-                    monitor.start();
-                    taskDone();
-                },
-                (taskDone) => {
-                    server = http.createServer(function(req, res) {
-                        res.writeHead(200, {'Content-Type': 'text/plain'});
-                        res.end('I am being monitored\n');
-                    });
-                    server.listen(0, () => {
-                        port = server.address().port;
-                        taskDone();
-                    });
-                },
-                (taskDone) => {
-                    http.get('http://127.0.0.1:' + port, (res) => {
-                        res.on('data', () => {});   // drain response body
-                        topic.totalRequests = process.monitor.getTotalRequestCount();
-                        topic.requests = process.monitor.getRequestCount();
-                        topic.openConnections = process.monitor.getOpenConnections();
-                        topic.transferred = process.monitor.getTransferred();
-                        taskDone();
-                    }).on('error', taskDone);
-                },
-                (taskDone) => {
-                    socket = dgram.createSocket('unix_dgram', function(msg) {
-                        topic.msg = msg.toString();
-                        // we just grab one message
-                        taskDone();
-                    });
-                    var um = process.umask(0);
-                    socket.bind(monitor.ipcMonitorPath);
-                    process.umask(um);
-                },
-            ], done);
+        before(async function() {
+            monitor.setIpcMonitorPath(ipcMonitorPath);
+            monitor.start();
+
+            server = http.createServer(function(req, res) {
+                res.writeHead(200, {'Content-Type': 'text/plain'});
+                res.end('I am being monitored\n');
+            });
+            await new Promise((resolve) => server.listen(0, resolve));
+            port = server.address().port;
+
+            await new Promise((resolve, reject) => {
+                http.get('http://127.0.0.1:' + port, (res) => {
+                    res.on('data', () => {});   // drain response body
+                    topic.totalRequests = process.monitor.getTotalRequestCount();
+                    topic.requests = process.monitor.getRequestCount();
+                    topic.openConnections = process.monitor.getOpenConnections();
+                    topic.transferred = process.monitor.getTransferred();
+                    resolve();
+                }).on('error', reject);
+            });
+
+            await new Promise((resolve) => {
+                socket = dgram.createSocket('unix_dgram', function(msg) {
+                    topic.msg = msg.toString();
+                    // we just grab one message
+                    resolve();
+                });
+                bindWithOpenUmask(socket, monitor.ipcMonitorPath);
+            });
         });
-        after(function(done) {
-            // always do this cleanup
-            async.series([
-                (taskDone) => {
-                    socket.close();
-                    taskDone();
-                },
-                (taskDone) => {
-                    server.close(taskDone);
-                },
-                (taskDone) => {
-                    fs.unlink(monitor.ipcMonitorPath, taskDone);
-                },
-            ], done);
+
+        after(async function() {
+            socket.close();
+            await new Promise((resolve) => server.close(resolve));
+            await fsp.unlink(monitor.ipcMonitorPath);
         });
 
         it('should return values', function() {
@@ -154,61 +145,47 @@ describe('monitr', function() {
         });
 
         it('should have valid JSON', function() {
-            var msg = JSON.parse(topic.msg);
+            const msg = JSON.parse(topic.msg);
             assert.ok(Object.prototype.hasOwnProperty.call(msg, 'status'));
-            var status = msg.status;
+            const status = msg.status;
             assert.deepEqual(expectedProperties.sort(), Object.keys(status).sort());
-            var gc = status.gc;
+            const gc = status.gc;
             assert.deepEqual(expectedGCCollectors.sort(), Object.keys(gc).sort());
             Object.keys(gc).forEach((coll) => {
-                var fields = gc[coll];
+                const fields = gc[coll];
                 assert.deepEqual(expectedGCStatProperties.sort(), Object.keys(fields).sort());
             });
         });
     });
 
     describe('health check values', function() {
-        var socket;
-        var topic = {};
+        let socket;
+        const topic = {};
 
-        this.timeout(20000);
-        before(function(done) {
-            async.series([
-                (taskDone) => {
-                    monitor.setIpcMonitorPath(ipcMonitorPath);
-                    monitor.start();
-                    process.monitor.setHealthStatus(true, 200);
-                    taskDone();
-                },
-                (taskDone) => {
-                    socket = dgram.createSocket('unix_dgram', function(msg) {
-                        topic.isDown = process.monitor.isDown();
-                        topic.statusCode = process.monitor.getStatusCode();
-                        topic.statusTimestamp = process.monitor.getStatusTimestamp();
-                        topic.statusDate = process.monitor.getStatusDate();
-                        topic.msg = JSON.parse(msg.toString());
-                        // wait for one with health status
-                        if (topic.msg.status.health_status_code) {
-                            taskDone();
-                        }
-                    });
-                    var um = process.umask(0);
-                    socket.bind(monitor.ipcMonitorPath);
-                    process.umask(um);
-                },
-            ], done);
-        });
-        after(function(done) {
-            // always do this cleanup
-            async.series([
-                (taskDone) => {
-                    socket.close();
-                    taskDone();
-                },
-                (taskDone) => {
-                    fs.unlink(monitor.ipcMonitorPath, taskDone);
-                },
-            ], done);
+        before(async function() {
+            monitor.setIpcMonitorPath(ipcMonitorPath);
+            monitor.start();
+            process.monitor.setHealthStatus(true, 200);
+
+            await new Promise((resolve) => {
+                socket = dgram.createSocket('unix_dgram', function(msg) {
+                    topic.isDown = process.monitor.isDown();
+                    topic.statusCode = process.monitor.getStatusCode();
+                    topic.statusTimestamp = process.monitor.getStatusTimestamp();
+                    topic.statusDate = process.monitor.getStatusDate();
+                    topic.msg = JSON.parse(msg.toString());
+                    // wait for one with health status
+                    if (topic.msg.status.health_status_code) {
+                        resolve();
+                    }
+                });
+                bindWithOpenUmask(socket, monitor.ipcMonitorPath);
+            });
+        }, { timeout: 20000 });
+
+        after(async function() {
+            socket.close();
+            await fsp.unlink(monitor.ipcMonitorPath);
         });
 
         it('has valid information', function() {


### PR DESCRIPTION
Replace the NAN binding layer with node-addon-api, keeping direct V8 only for the three capabilities N-API does not expose: GC prologue/ epilogue callbacks, heap statistics, and isolate interrupt + stack trace. The monitr pthread now schedules work back onto the JS thread via a Napi::ThreadSafeFunction instead of uv_async_send, and Stop() shuts the thread down cleanly (flag + self-pipe wake + join) before releasing the TSFN.

Tooling/dependency modernization:
- drop nan as a direct dependency (now only transitive via unix-dgram)
- bump engines to >=20; CI matrix 20/22/24/26
- update to ESLint 10 with a native flat config (drop FlatCompat / @eslint/eslintrc)
- remove mocha: migrate tests to the built-in node:test runner and native async/await; drop async, mocha, eslint-plugin-mocha, global
- keep nyc for consistent lcov coverage

All 7 tests pass and lint is clean.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
